### PR TITLE
https://github.com/uavorg/uavstack/issues/197

### DIFF
--- a/com.creditease.uav.helper/src/main/java/com/creditease/agent/helpers/JVMToolHelper.java
+++ b/com.creditease.uav.helper/src/main/java/com/creditease/agent/helpers/JVMToolHelper.java
@@ -34,6 +34,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -59,6 +61,7 @@ import com.creditease.agent.helpers.jvmtool.JVMPropertyFilter;
 public class JVMToolHelper {
 
     public static final String osname = System.getProperty("os.name").toLowerCase();
+	public static final String username = System.getProperty("user.name");
     public static final String JMX_CONNECTOR_ADDRESS = "com.sun.management.jmxremote.localConnectorAddress";
 
     private static ClassLoader JVMToolClassloader = null;
@@ -188,7 +191,12 @@ public class JVMToolHelper {
              */
             try {
                 String id = (String) method_VMId.invoke(vmInstance, (Object[]) null);
-
+				
+				//if the jvm is not started by the same user as MA, do not attach it (just in case of linux)             
+                if(isLinux() && !username.equals(Files.getOwner(Paths.get(("/proc/"+id))).getName())) {
+                    continue;
+                }
+				
                 Object vm = method_AttachToVM.invoke(null, id);
 
                 if (vm == null) {
@@ -389,7 +397,17 @@ public class JVMToolHelper {
 
         return (osname.indexOf("win") > -1) ? true : false;
     }
+	
+	/**
+     * isLinux
+     * 
+     * @return
+     */
+    public static boolean isLinux() {
 
+        return (osname.indexOf("linux") > -1) ? true : false;
+    }
+	
     /**
      * getLineSeperator
      * 


### PR DESCRIPTION
#197 target jvm output dump when MA attach other user's jvm

1.modify method getAllVMsInfo，do not attch the jvm which is not started by the same user as ma.